### PR TITLE
fix: ensure additional sans are processed correctly

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -396,7 +396,11 @@ func (k *talosProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest
 		}
 
 		if additionalSANsUnTyped, ok := inputsMap["additionalSans"]; ok {
-			additionalSANs := additionalSANsUnTyped.([]string)
+			additionalSANs := []string{}
+
+			for _, additionalSANsItemUnTyped := range additionalSANsUnTyped.([]interface{}) {
+				additionalSANs = append(additionalSANs, additionalSANsItemUnTyped.(string))
+			}
 
 			genOptions = append(genOptions, generate.WithAdditionalSubjectAltNames(additionalSANs))
 			outputs["additionalSans"] = additionalSANs


### PR DESCRIPTION
This PR fixes a small bug where the list of additional sans is actually
a []interface{}, so we must range over that list of interfaces and
append each item to a string list instead.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>